### PR TITLE
Fix bandpass_filter.filter flag and improve output

### DIFF
--- a/src/functional_pipeline/compute_motion_metrics.m
+++ b/src/functional_pipeline/compute_motion_metrics.m
@@ -3,7 +3,7 @@ function compute_motion_metrics(configParams)
 %% Initialization
 status.compute_motion_metrics = 'running';
 updateStatus(configParams.general.statusFile, status);
-fprintf('---Compute_motion_metrics started----\n');
+fprintf('---compute_motion_metrics started----\n');
 
 %% Computation motion metrics
 motionParametersFile = configParams.functional_preprocessing.motionParametersFile;


### PR DESCRIPTION
Fix the bug that setting the `bandpass_filter.filter` flag to false did not disable band-pass filtering. Further update the output of the `reconstruction_functional_network` step to highlight the processing steps performed.