### PR TITLE
readTrk bug

### DIFF
--- a/src/misc/readTrk.m
+++ b/src/misc/readTrk.m
@@ -34,11 +34,6 @@ while true
         break;
     end
 
-    % We need at least 3 steps (1 WM voxel).
-    if points < 5 
-        continue
-    end
-
     fibers{iFiber} = thisFiber;
     
 end


### PR DESCRIPTION
Update helper function readTrk (that is not used in the pipeline), such that short fibers are included in the output cell array with fibers.