### PR TITLE
Fix bbregister cleanup (copy of PR #1)

### DIFF
--- a/src/functional_preprocessing/preprocess_default.sh
+++ b/src/functional_preprocessing/preprocess_default.sh
@@ -148,7 +148,7 @@ fi
 
 bbregister --s "$freesurferDir" --mov "$fmriReferenceFile" --reg "$registrationMatrixFile" \
     --bold --init-fsl
-rm -f "`basename $registrationMatrixFile .dat`".{dat.mincost,dat.param,dat.sum,dat.log,log}
+rm -f "${registrationMatrixFile%.dat}".{dat.mincost,dat.param,dat.sum,dat.log,log}
 
 # register freesurfer segmentation to reference volume
 mri_label2vol --seg "${freesurferDir}/mri/aseg.mgz" --temp "$fmriReferenceFile" \

--- a/src/functional_preprocessing/preprocess_default.sh
+++ b/src/functional_preprocessing/preprocess_default.sh
@@ -148,7 +148,7 @@ fi
 
 bbregister --s "$freesurferDir" --mov "$fmriReferenceFile" --reg "$registrationMatrixFile" \
     --bold --init-fsl
-rm "$registrationMatrixFile".{mincost,param,sum,log}
+rm "`basename $registrationMatrixFile .dat`".{dat.mincost,dat.param,dat.sum,log}
 
 # register freesurfer segmentation to reference volume
 mri_label2vol --seg "${freesurferDir}/mri/aseg.mgz" --temp "$fmriReferenceFile" \

--- a/src/functional_preprocessing/preprocess_default.sh
+++ b/src/functional_preprocessing/preprocess_default.sh
@@ -148,7 +148,7 @@ fi
 
 bbregister --s "$freesurferDir" --mov "$fmriReferenceFile" --reg "$registrationMatrixFile" \
     --bold --init-fsl
-rm "`basename $registrationMatrixFile .dat`".{dat.mincost,dat.param,dat.sum,log}
+rm -f "`basename $registrationMatrixFile .dat`".{dat.mincost,dat.param,dat.sum,dat.log,log}
 
 # register freesurfer segmentation to reference volume
 mri_label2vol --seg "${freesurferDir}/mri/aseg.mgz" --temp "$fmriReferenceFile" \

--- a/src/structural_preprocessing/preprocess_eddy.sh
+++ b/src/structural_preprocessing/preprocess_eddy.sh
@@ -186,7 +186,7 @@ computeReferenceB0
 # Compute registration matrix from FS to subject space
 bbregister --s "$freesurferDir" --mov "$dwiReferenceFile" --reg "$registrationMatrixFile" \
     --dti --init-fsl
-rm -f "`basename $registrationMatrixFile .dat`".{dat.mincost,dat.param,dat.sum,dat.log,log}
+rm -f "${registrationMatrixFile%.dat}".{dat.mincost,dat.param,dat.sum,dat.log,log}
 
 # Register freesurfer segmentation to reference volume
 mri_label2vol --seg "${freesurferDir}/mri/aseg.mgz" --temp "$dwiReferenceFile" \

--- a/src/structural_preprocessing/preprocess_eddy.sh
+++ b/src/structural_preprocessing/preprocess_eddy.sh
@@ -186,7 +186,7 @@ computeReferenceB0
 # Compute registration matrix from FS to subject space
 bbregister --s "$freesurferDir" --mov "$dwiReferenceFile" --reg "$registrationMatrixFile" \
     --dti --init-fsl
-rm "`basename $registrationMatrixFile .dat`".{dat.mincost,dat.param,dat.sum,log}
+rm -f "`basename $registrationMatrixFile .dat`".{dat.mincost,dat.param,dat.sum,dat.log,log}
 
 # Register freesurfer segmentation to reference volume
 mri_label2vol --seg "${freesurferDir}/mri/aseg.mgz" --temp "$dwiReferenceFile" \

--- a/src/structural_preprocessing/preprocess_eddy.sh
+++ b/src/structural_preprocessing/preprocess_eddy.sh
@@ -186,7 +186,7 @@ computeReferenceB0
 # Compute registration matrix from FS to subject space
 bbregister --s "$freesurferDir" --mov "$dwiReferenceFile" --reg "$registrationMatrixFile" \
     --dti --init-fsl
-rm "$registrationMatrixFile".{mincost,param,sum,log}
+rm "`basename $registrationMatrixFile .dat`".{dat.mincost,dat.param,dat.sum,log}
 
 # Register freesurfer segmentation to reference volume
 mri_label2vol --seg "${freesurferDir}/mri/aseg.mgz" --temp "$dwiReferenceFile" \

--- a/src/structural_preprocessing/preprocess_minimal.sh
+++ b/src/structural_preprocessing/preprocess_minimal.sh
@@ -114,7 +114,7 @@ rm "${dwiReferenceFile/.nii.gz/_indv_}"*.nii.gz
 # compute registration matrix
 bbregister --s "$freesurferDir" --mov "$dwiReferenceFile" --reg "$registrationMatrixFile" \
     --dti --init-fsl
-rm "$registrationMatrixFile".{mincost,param,sum,log}
+rm "`basename $registrationMatrixFile .dat`".{dat.mincost,dat.param,dat.sum,log}
 
 # register freesurfer segmentation to reference volume
 mri_label2vol --seg "${freesurferDir}/mri/aseg.mgz" --temp "$dwiReferenceFile" \

--- a/src/structural_preprocessing/preprocess_minimal.sh
+++ b/src/structural_preprocessing/preprocess_minimal.sh
@@ -114,7 +114,7 @@ rm "${dwiReferenceFile/.nii.gz/_indv_}"*.nii.gz
 # compute registration matrix
 bbregister --s "$freesurferDir" --mov "$dwiReferenceFile" --reg "$registrationMatrixFile" \
     --dti --init-fsl
-rm -f "`basename $registrationMatrixFile .dat`".{dat.mincost,dat.param,dat.sum,dat.log,log}
+rm -f "${registrationMatrixFile%.dat}".{dat.mincost,dat.param,dat.sum,dat.log,log}
 
 # register freesurfer segmentation to reference volume
 mri_label2vol --seg "${freesurferDir}/mri/aseg.mgz" --temp "$dwiReferenceFile" \

--- a/src/structural_preprocessing/preprocess_minimal.sh
+++ b/src/structural_preprocessing/preprocess_minimal.sh
@@ -114,7 +114,7 @@ rm "${dwiReferenceFile/.nii.gz/_indv_}"*.nii.gz
 # compute registration matrix
 bbregister --s "$freesurferDir" --mov "$dwiReferenceFile" --reg "$registrationMatrixFile" \
     --dti --init-fsl
-rm "`basename $registrationMatrixFile .dat`".{dat.mincost,dat.param,dat.sum,log}
+rm -f "`basename $registrationMatrixFile .dat`".{dat.mincost,dat.param,dat.sum,dat.log,log}
 
 # register freesurfer segmentation to reference volume
 mri_label2vol --seg "${freesurferDir}/mri/aseg.mgz" --temp "$dwiReferenceFile" \

--- a/src/structural_preprocessing/preprocess_topup_eddy.sh
+++ b/src/structural_preprocessing/preprocess_topup_eddy.sh
@@ -197,7 +197,7 @@ computeReferenceB0
 # Compute registration matrix from FS to subject space
 bbregister --s "$freesurferDir" --mov "$dwiReferenceFile" --reg "$registrationMatrixFile" \
 --dti --init-fsl
-rm "`basename $registrationMatrixFile .dat`".{dat.mincost,dat.param,dat.sum,log}
+rm -f "`basename $registrationMatrixFile .dat`".{dat.mincost,dat.param,dat.sum,dat.log,log}
 
 # Register freesurfer segmentation to reference volume
 mri_label2vol --seg "${freesurferDir}/mri/aseg.mgz" --temp "$dwiReferenceFile" \

--- a/src/structural_preprocessing/preprocess_topup_eddy.sh
+++ b/src/structural_preprocessing/preprocess_topup_eddy.sh
@@ -197,7 +197,7 @@ computeReferenceB0
 # Compute registration matrix from FS to subject space
 bbregister --s "$freesurferDir" --mov "$dwiReferenceFile" --reg "$registrationMatrixFile" \
 --dti --init-fsl
-rm "$registrationMatrixFile".{mincost,param,sum,log}
+rm "`basename $registrationMatrixFile .dat`".{dat.mincost,dat.param,dat.sum,log}
 
 # Register freesurfer segmentation to reference volume
 mri_label2vol --seg "${freesurferDir}/mri/aseg.mgz" --temp "$dwiReferenceFile" \

--- a/src/structural_preprocessing/preprocess_topup_eddy.sh
+++ b/src/structural_preprocessing/preprocess_topup_eddy.sh
@@ -197,7 +197,7 @@ computeReferenceB0
 # Compute registration matrix from FS to subject space
 bbregister --s "$freesurferDir" --mov "$dwiReferenceFile" --reg "$registrationMatrixFile" \
 --dti --init-fsl
-rm -f "`basename $registrationMatrixFile .dat`".{dat.mincost,dat.param,dat.sum,dat.log,log}
+rm -f "${registrationMatrixFile%.dat}".{dat.mincost,dat.param,dat.sum,dat.log,log}
 
 # Register freesurfer segmentation to reference volume
 mri_label2vol --seg "${freesurferDir}/mri/aseg.mgz" --temp "$dwiReferenceFile" \


### PR DESCRIPTION
This PR is a copy of #1 by @koenhelwegen. This PR makes the cleanup of the files produced by `bbregister` in the preprocessing step compatible with both FreeSurfer version 6 and 7. See the original pull request for further details. 

I was not able to merge the original pull request into develop and decided to make a cherry-picked copy to avoid merging problems (that might have resulted from hard-resets in the past).