### PR TITLE
Use iRESTORE threshold parameters from configuration

### DIFF
--- a/src/structural_pipeline/Reconstruction-Diffusion/reconstruction_diffusion.m
+++ b/src/structural_pipeline/Reconstruction-Diffusion/reconstruction_diffusion.m
@@ -28,6 +28,10 @@ diffusionMeasuresFile = configParams.reconstruction_diffusion.diffusionMeasuresF
 nonlinearitiesFlag = configParams.reconstruction_diffusion.gradientNonlinearities.correctNonlinearities;
 nonlinearitiesFile = configParams.reconstruction_diffusion.gradientNonlinearities.nonlinearitiesFile;
 
+thresCondNum = configParams.reconstruction_diffusion.DTI.thresCondNum;
+thresVarProjScores = configParams.reconstruction_diffusion.DTI.thresVarProjScores;
+
+
 % Load processed DWI file.
 try
     dwi = load_nifti(dwiProcessedFile);
@@ -76,7 +80,13 @@ nVoxels = size(signalIntensities, 1);
 if any(strcmpi(reconMethods, 'dti'))
     fprintf('reconstruction method: DTI\n');
     
-    [thresCondNum, thresVarProjScores] = thresholdAssistant(gtab);
+    if isempty(thresCondNum) | isempty(thresVarProjScores)
+        [thresCondNum, thresVarProjScores] = thresholdAssistant(gtab);
+        fprintf('Estimated iRESTORE thresholds:\n\tthresCondNum = %.3g, thresVarProjScores = %.3g\n', thresCondNum, thresVarProjScores);
+    else
+        fprintf('iRESTORE thresholds from configuration file:\n\tthresCondNum = %.3g, thresVarProjScores = %.3g\n', thresCondNum, thresVarProjScores);
+    end
+
     
     diffusionTensors = nan(nVoxels, 6);
     if ~nonlinearitiesFlag

--- a/tests/structural_pipeline/test_reconstruction_diffusion.m
+++ b/tests/structural_pipeline/test_reconstruction_diffusion.m
@@ -121,5 +121,39 @@ classdef test_reconstruction_diffusion < matlab.unittest.TestCase
 
         end
         
+        function testThresholdAssistant(testCase, subjectDir)
+            
+            % Test threshold parameters estimated by threshold assistant
+            cs = structural_pipeline(pwd, ...
+                'configurationFile', fullfile(subjectDir, 'config_SC_ref.json'), ...
+                'reconstructionSteps', 'reconstruction_diffusion', ...
+                'general.reconstructionMethods', 'dti', ...
+                'general.outputDir', 'DWI_processed_test', 'runType', 'overwrite' ...
+            );    
+        
+            testCase.assertTrue(isfile(cs.general.logFile));
+            logText = textread(cs.general.logFile, '%s', 'delimiter', '####');
+            logText = [logText{:}];
+            testCase.assertTrue(contains(logText, 'Estimated iRESTORE thresholds'));
+
+            % Test threshold parameters specified in configuration
+            cs = structural_pipeline(pwd, ...
+                'configurationFile', fullfile(subjectDir, 'config_SC_ref.json'), ...
+                'reconstructionSteps', 'reconstruction_diffusion', ...
+                'general.reconstructionMethods', 'dti', ...
+                'general.outputDir', 'DWI_processed_test', 'runType', 'overwrite', ...
+                'reconstruction_diffusion.DTI.thresCondNum', 2.11, ...
+                'reconstruction_diffusion.DTI.thresVarProjScores', 0.0916);
+        
+            testCase.assertTrue(isfile(cs.general.logFile));
+            logText = textread(cs.general.logFile, '%s', 'delimiter', '####');
+            logText = [logText{:}];
+            testCase.assertTrue(contains(logText, 'iRESTORE thresholds from configuration file:'));
+            testCase.assertTrue(contains(logText, 'thresCondNum = 2.11, thresVarProjScores = 0.0916'));
+            
+            
+        end
+            
+        
     end
 end


### PR DESCRIPTION
Estimated iRESTORE thresholds were used, even when the user provided them as parameters in the configuration file. I have updated the `reconstruction_diffusion` function to use the user-provided values when possible. Furthermore, I added a test case that validates that the correct (estimated or user-provided) parameters are used.