### PR TITLE
Fix bandpass filter

### DIFF
--- a/src/functional_pipeline/reconstruction_functional_network.m
+++ b/src/functional_pipeline/reconstruction_functional_network.m
@@ -115,10 +115,11 @@ for iMethod = 1:length(methods)
     % Normalize regressors to avoid non-invertible matrices.
     regressors = bsxfun(@rdivide, regressors, mean(abs(regressors), 2));
 
-    % Slow implementation:
-    %     % Add column of constants for regress function.
-    %     regressors = [ones(1, size(regressors, 2)); regressors];
+    % Add column of constants.
+    regressors = [ones(1, size(regressors, 2)); regressors];
     
+    % Slow implementation:
+    %
     %     % Apply regressors
     %     selectedTimeSeries = fmri.Data.signalIntensities(selectedVoxels, :);
     %     

--- a/tests/functional_pipeline/test_reconstruction_functional_network.m
+++ b/tests/functional_pipeline/test_reconstruction_functional_network.m
@@ -54,12 +54,72 @@ classdef test_reconstruction_functional_network < matlab.unittest.TestCase
                 ref = load(strrep(connectivityMatrixFile, 'fMRI_processed_test', 'CATO_ref'));
                 
                 r = corr(squareform(ref.connectivity)', squareform(obs.connectivity)');
-                testCase.verifyGreaterThanOrEqual(r, 0.98, ...
+                testCase.verifyGreaterThanOrEqual(r, 0.97, ...
                     sprintf('%s FC matrix do not correlate enough.', reconstructionMethods{1}));
                 
             end
             
         end
+        
+        function reconstruction_functional_network_bandpass_filter(testCase, subjectDir)
+            % Test the bandpass filter step by adding low and high
+            % frequency noise.
+            
+            % Load original time series.  Voxel in (1,1,1) is a regressor
+            % and has normal distributed random signal.
+            NT = load_nifti(fullfile(subjectDir, 'CATO_ref/FC_default_fmri.nii.gz'));
+            S = NT.vol;
+            noiseVoxel = NT.vol(1,1,1,:);                        
+            repetitionTime = NT.pixdim(5);
+            nScans = size(S,4);
+                       
+            % Add low and high fequency noise.
+            regionPhase = pi .* (linspace(0, 1, 16)'); % 16 brain regions
+            regionPhase = regionPhase(randperm(length(regionPhase)));
+            noiseLowFreq = 100 * sin([0:(nScans-1)] * 2*pi * (repetitionTime * 0.0066 / 1000)  - regionPhase);
+            noiseHighFreq =  100 * sin([0:(nScans-1)] * 2*pi * (repetitionTime * 0.17 / 1000)  - regionPhase);
+            
+            noise = noiseLowFreq + noiseHighFreq;
+            noise = permute(noise, [1 3 4 2]);
+            noise = reshape(noise, sqrt(16), sqrt(16), 1, []);
+            noise = repelem(noise, 2,2,3);
+            noise = noise - min(noise(:));
+            
+            NT.vol = S + 1*noise;
+            NT.vol(1,1,1,:) = noiseVoxel - min(noiseVoxel);
+            save_nifti(NT, fullfile(pwd, 'fMRI_processed_test/FC_default_fmri_bandpass_filter.nii.gz'));
+                        
+            % Run CATO with bandpass filtering ([0.01 - 0.1]).
+            cf = functional_pipeline(pwd, ...
+                'configurationFile', fullfile(subjectDir, 'config_FC_ref.json'), ...
+                'reconstructionSteps', testCase.reconstructionSteps, ...
+                'general.outputDir', 'fMRI_processed_test', ...
+                'functional_preprocessing.fmriProcessedFile', 'OUTPUTDIR/SUBJECT_fmri_bandpass_filter.nii.gz', ...
+                'reconstruction_functional_network.bandpass_filter.filter' , true, ...
+                'reconstruction_functional_network_1.bandpass_filter.filter' , true, ...                
+                'runType', 'overwrite');
+            
+            for reconstructionMethods = {'default'}
+
+                connectivityMatrixFile = strrep(strrep( ...
+                    cf.reconstruction_functional_network.connectivityMatrixFile, ...
+                    'METHOD', reconstructionMethods{1}), ...
+                    'TEMPLATE', 'toyAtlas1');           
+                
+                obs = load(connectivityMatrixFile);
+                ref = load(strrep(connectivityMatrixFile, 'fMRI_processed_test', 'CATO_ref'));
+                
+                r = corr(squareform(ref.connectivity)', squareform(obs.connectivity)');
+                testCase.verifyGreaterThanOrEqual(r, 0.98, ...
+                    sprintf('%s FC matrices differ too much (in correlation).', reconstructionMethods{1}));
+                
+                d = mean(abs((squareform(ref.connectivity) - squareform(obs.connectivity))));
+                testCase.verifyLessThanOrEqual(d, 0.05, ...
+                    sprintf('%s FC matrices differ too much (in absolute distance).', reconstructionMethods{1}));                
+                
+            end
+            
+        end        
         
         
         

--- a/tests/run_testSuite.m
+++ b/tests/run_testSuite.m
@@ -1,4 +1,12 @@
 %% Initialize
+
+% test suite requires MATLAB version 2018b or newer
+if verLessThan('matlab','9.5')
+    warning('CATO:testSuite:NotCompatible', ...
+        ['CATO test suite requires MATLAB 2018b (or newer).']);
+end
+
+
 testDir = fileparts(mfilename('fullpath'));
 assetsDir = fullfile(testDir, 'assets');
 testSubjectsDir = fullfile(testDir, 'testSubjects');
@@ -23,11 +31,11 @@ testSubjectsFC = simulate_functional_data(testSubjectsDir);
 testSubjectsSC = simulate_structural_data(testSubjectsDir);
 
 %% Create and run test suite
-import matlab.unittest.TestSuite
+import matlab.unittest.TestSuite;
 
-import matlab.unittest.parameters.Parameter
+import matlab.unittest.parameters.Parameter;
 import matlab.unittest.selectors.HasParameter;
-import matlab.unittest.constraints.StartsWithSubstring
+import matlab.unittest.constraints.StartsWithSubstring;
 % Option: Add HasParameter('Name','csd') as input variable to
 % TestSuite.fromFolder() to select specific tests (where csd is tested).
 


### PR DESCRIPTION
This PR modifies the filtering behavior in two ways:
- it removes the matching of the initial and final timepoints of the unfiltered signals, as these are often outliers from the perspective of the filtered signal;
- it pads the signal using the the time-mirrored timeseries, not the inverted time-mirrored timeseries.

closes #27 