### PR TITLE
Improve error messages for reading/writing fiber files

### DIFF
--- a/src/misc/readTrk.m
+++ b/src/misc/readTrk.m
@@ -12,7 +12,12 @@ function [fibers, header] = readTrk(fiberFile)
 %   header:
 %   Header of fiber file.
 
-[fid, message] = fopen(fiberFile, 'r');
+[fid, errorMessage] = fopen(fiberFile, 'r');
+
+if fid == -1
+    error('CATO:readTrk:fileNotFound', '%s ''%s''.', errorMessage, fiberFile);
+end
+
 header = readTrkHeader(fid);
 
 iFiber = 0;

--- a/src/misc/trackvis_tools/writeTrkHeader.m
+++ b/src/misc/trackvis_tools/writeTrkHeader.m
@@ -11,13 +11,17 @@ function writeTrkHeader(fid, header)
 %   which is distributed under the GPL-3.0 License
 
 % Check orientation
+assert(any(header.image_orientation_patient), ...
+    ['Track file header has empty "image_orientation_patient" field.\n', ... 
+    'The image orientation cannot be determined.']);
+
 [~, ix] = max(abs(header.image_orientation_patient(1:3)));
 [~, iy] = max(abs(header.image_orientation_patient(4:6)));
 iz = 1:3;
 iz([ix iy]) = [];
 assert(isequal([ix iy iz], [1 2 3]), ...
-    ['Image orientation of the original image is assumed LPS. Other ', ...
-    'orientations are not supported.']);
+    ['Track file header contains and unsuported image orientation ([%g %g %g]).\n', ...
+    'Only "LPS" ([1 2 3]) is supported'], ix, iy, iz);
 
 % Write TrackVis header
 fwrite(fid, charpad(header.id_string, 1, 6), 'char*1');


### PR DESCRIPTION
This pull request improves the error messaging for two scenarios:
* When attempting to open a fiber file that does not exist, the error message will now provide more specific information to help the user identify the issue.
* When attempting to write a fiber file with missing "image_orientation_patient" information or with an unsupported image orientation, the error message will provide more detailed information about the issue.
