### PR TITLE
Add compatibility for complex vox2ras matrices

### DIFF
--- a/src/misc/nifti_orientation.m
+++ b/src/misc/nifti_orientation.m
@@ -1,0 +1,50 @@
+function orientationStr = nifti_orientation(vox2ras)
+% NIFTI_ORIENTATION computes the orientation string from the vox2ras
+% matrix.
+%
+% Input:
+%   vox2ras: a 4x4 matrix (typically the vox2ras parameter from the
+%   NIFTI file header).
+%
+% Output:
+%   orientation_str: a string indicating the orientation (e.g. 'RAS' or
+%   'LPI').
+
+% Notes:
+% For more information on the vox2ras transformation see the FreeSurfer
+% documentation:
+% https://surfer.nmr.mgh.harvard.edu/fswiki/CoordinateSystems
+
+% Extract the direction cosine matrix (3x3)
+R = vox2ras(1:3, 1:3);
+
+% Compute the orientation codes
+orientationCode = zeros(1, 3);
+for i = 1:3
+    [~, maxIndx] = max(abs(R(:,i)));
+    if R(maxIndx, i) > 0
+        orientationCode(i) = maxIndx;
+    else
+        orientationCode(i) = -maxIndx;
+    end
+end
+
+% Convert orientation codes to orientation string
+orientationStr = '???';
+for i = 1:3
+    switch orientationCode(i)
+        case 1
+            orientationStr(i) = 'R';
+        case -1
+            orientationStr(i) = 'L';
+        case 2
+            orientationStr(i) = 'A';
+        case -2
+            orientationStr(i) = 'P';
+        case 3
+            orientationStr(i) = 'S';
+        case -3
+            orientationStr(i) = 'I';
+    end
+end
+end

--- a/src/structural_pipeline/Reconstruction-Fibers/reconstruction_fibers.m
+++ b/src/structural_pipeline/Reconstruction-Fibers/reconstruction_fibers.m
@@ -39,11 +39,7 @@ trkheader.vox_to_ras = data.vox2ras;
 segmentationVol = data.vol;
 
 % Extracte orientation from transformation
-props = data.vox2ras(1:3, 1:3);
-[I, ~] = find(props); 
-I = (I-1)*2+ 1 + (props([0 3 6]' + I) > 0);
-orientationOptions = ['L' 'R', 'P', 'A', 'I', 'S']';
-orientation = orientationOptions(I)';
+orientation = nifti_orientation(data.vox2ras);
 
 clear data
 


### PR DESCRIPTION
The previous implementation assumed a single term per column in the vox2ras matrix of the segmentationFile NIfTI. However, if a vox2ras matrix with multiple terms was used,  CATO would throw an error. This PR adds compatibility for such complex vox2ras matrices. Additionally, the tests have been updated to include these complex vox2ras matrices (with mri_info as reference).