### PR TITLE
Fix multiple reconstruction steps via commandline

### DIFF
--- a/src/misc/parseVarargin.m
+++ b/src/misc/parseVarargin.m
@@ -48,7 +48,7 @@ while ~isempty(varargin)
             assert(ismember(runType, {'none', 'continue', 'overwrite'}));
             runType = varValue;
             
-        case 'reconstructionsteps'
+        case 'reconstructionSteps'
             
             % Command line uses ',' to split reconstruction steps.
             if ischar(varValue)


### PR DESCRIPTION
Due to a small typo the case of multiple reconstruction steps was not handled correctly