### PR TITLE
Use existing acqpFile

### DIFF
--- a/src/structural_pipeline/Preprocessing/structural_preprocessing.m
+++ b/src/structural_pipeline/Preprocessing/structural_preprocessing.m
@@ -64,11 +64,17 @@ end
 
 %% Prepare index, acqp, bvals and bvecs for Eddy and Topup
 
+% Read acqFile if it exists and is compatible
+if exist(acqpFile, 'file')
+    acqp = dlmread(acqpFile);
+    assert(size(acqp, 2) == 4);
+% otherwise create a new acqFile using the revPhaseEncDim and acqpFactor
+else
+    acqp = zeros(2, 4);
+    acqp(:, 4) = acqpFactor;
+    acqp(1, revPhaseEncDim) = 1; acqp(2, revPhaseEncDim) = -1;
+end
 
-% Create acquisition parameters matrix
-acqp = zeros(2, 4);
-acqp(:, 4) = acqpFactor;
-acqp(1, revPhaseEncDim) = 1; acqp(2, revPhaseEncDim) = -1;
 
 % Case 1: One set (Minimal or Eddy preprocessing)
 if isempty(dwiFileReversed) && isempty(dwiB0OnlyReversed)


### PR DESCRIPTION
**Modification:**
If acqpFile exists and has the required dimensions, it can directly be used in the preprocessing steps.
Otherwise acqpFile is created according to the original code.

**Problem:**
Some Topup cases require a specific acqpFile. Tool such as [SynB0-DISCO](https://github.com/MASILab/Synb0-DISCO/tree/master) can synthesize a b0 image for diffusion distortion correction. When running Topup, the acqpFile should contain two rows in the same direction (see example below). 
CATO currently auto generates an acqpFile and overwrites existing files in the location. 

```
$ cat acqparams.txt 
0 1 0 0.062
0 1 0 0.000
```
